### PR TITLE
[Fix] RestDocs gradle 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ configurations {
 bootJar {
     archiveFileName = 'app.jar'
     dependsOn asciidoctor
-    from("${asciidoctor.outputDir}") {
+    from(asciidoctor.outputDir) {
         into 'static/docs'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ configurations {
 
 bootJar {
     archiveFileName = 'app.jar'
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }
 
 repositories {
@@ -39,7 +43,6 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.1'
-
 
     //spring
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -65,7 +68,6 @@ dependencies {
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     //restDocs
@@ -81,12 +83,4 @@ asciidoctor {
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'
     dependsOn test
-}
-
-bootJar {
-    dependsOn asciidoctor
-    copy{
-        from asciidoctor.outputDir
-        into "src/main/resources/static/docs"
-    }
 }


### PR DESCRIPTION
1. 중복되는 의존성을 제거하였습니다.
2. 빌드 결과물을 src에 넣지 않도록 변경하였습니다.